### PR TITLE
Add <textarea> to CODE_TAGS

### DIFF
--- a/appendChild.js
+++ b/appendChild.js
@@ -11,7 +11,7 @@ var TEXT_TAGS = [
 ]
 
 var CODE_TAGS = [
-  'code', 'pre'
+  'code', 'pre', 'textarea'
 ]
 
 module.exports = function appendChild (el, childs) {


### PR DESCRIPTION
## Summary
In order for `<textarea>` tags to be multiline, I believe they need to be included in CODE_TAGS.

## Testing
I have done no thorough testing, but after playing around with it in my own framework, this seemed to be the solution.